### PR TITLE
Use d_inline_code instead of d_inline_code CSS class

### DIFF
--- a/src/main.d
+++ b/src/main.d
@@ -115,7 +115,7 @@ string[string] readMacros(const string[] macroFiles)
 	string[string] rVal;
 	foreach (k, v; ddoc.macros.DEFAULT_MACROS)
 		rVal[k] = v;
-	rVal["D"]    = `<code class="d_inlinecode">$0</code>`;
+	rVal["D"]    = `<code class="d_inline_code">$0</code>`;
 	// These seem to be defined in Phobos, and apparently work in D code
 	// using some of its modules? Either way, needed for compatibility.
 	rVal["HTTP"] = "<a href=\"http://$1\">$+</a>";

--- a/strings/style.css
+++ b/strings/style.css
@@ -549,7 +549,7 @@ div.error {
 }
 
 /* Markdown inline code and $(D code) */
-code.prettyprint, .d_inlinecode {
+code.prettyprint, .d_inline_code {
 	font-family: monospace;
 	color: #333;
 	background-color:rgba(0,0,0,0.04);


### PR DESCRIPTION
libddoc declares D_INLINECODE macro with class d_inline_code
while harbored-mod CSS declares d_inlinecode.